### PR TITLE
Streamlabs OBS Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ Compiling:
 - Compile with visual studio. Only 64bit version has been tested.
 
 # Installation
-* Download latest zip release from https://github.com/baffler/OBS-OpenVR-Input-Plugin/releases (make sure not to download one labled "Source Code")
-* Close OBS if it's open
-* Your zip file should contain a "data" folder, "obs-plugins" folder and a readme file. If not, make sure you downloaded a release zip file and not the actual source code.
-* Extract the zip file into your OBS studio directory (typically installed in "C:\Program Files (x86)\obs-studio"). Choose Replace Files if prompted.
-* Launch OBS and add a new source to one of your scenes, the source name is "OpenVR Capture"
+* Download latest zip release from https://github.com/baffler/OBS-OpenVR-Input-Plugin/releases (make sure not to download one labled "Source Code").
+	- The zip file you download should contain a "data" and "obs-plugins" folder with a readme file. If not, makes sure to download the release zip file.
+* Close OBS Studio or Streamlabs OBS if it's open.
+* Extract the zip file into your OBS studio directory or Streamlabs OBS libobs directory.
+	- OBS Studio; typically installed in `C:\Program Files (x86)\obs-studio")` and choose Replace Files if prompted.
+	- Streamlabs OBS; typically installed in `C:\Program Files\Streamlabs OBS\resources\app.asar.unpacked\node_modules\obs-studio-node\libobs` and choose Replace Files if promted.
+* Launch OBS or Streamlabs OBS and add a new source to one of your scenes, the source name is "OpenVR Capture"
 
 ![Extract Files](https://user-images.githubusercontent.com/1980600/40620530-22aca280-6267-11e8-96dc-4978675d3e80.png)
 

--- a/plugins/win-openvr/win-openvr.cpp
+++ b/plugins/win-openvr/win-openvr.cpp
@@ -473,7 +473,7 @@ OBS_MODULE_USE_DEFAULT_LOCALE("win-openvr", "en-US")
 bool obs_module_load(void)
 {
 	obs_source_info info	= {};
-	info.id			= "win-openvr";
+	info.id			= "openvr_capture";
 	info.type		= OBS_SOURCE_TYPE_INPUT;
 	info.output_flags	= OBS_SOURCE_VIDEO |
 				  OBS_SOURCE_CUSTOM_DRAW;


### PR DESCRIPTION
Renamed plugin id to 'openvr_capture' for Streamlabs OBS compatibility and to be more in-line with other plugin id naming. Adjusted README to include Streamlabs OBS installation.