### PR TITLE
Add Quest 2 crop values

### DIFF
--- a/plugins/win-openvr/data/win-openvr-presets.ini
+++ b/plugins/win-openvr/data/win-openvr-presets.ini
@@ -2,3 +2,5 @@
 550,620,200,77,HTC Vive
 568,613,175,102,Valve Index
 634,656,180,66,Vive PRO
+640,542,0,0,Quest 2
+591,591,0,0,Quest 2 (center)


### PR DESCRIPTION
"Quest 2" is shifted down by 49 px and suited for gaming (e.g. handheld weapons are visible more, sky is less).
"Quest 2 (center)" is for other content (e.g. 360 videos).